### PR TITLE
Add roadmap and agent integration guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# TradeAgentEA Operating Guide
+
+These instructions govern changes within this repository. When modifying or extending functionality, ensure that TradeAgentEA continues to satisfy the requirements below.
+
+## AgentMode
+- TradeAgentEA operates in **synchronous relay** mode by default. Signals received must be validated and dispatched to broker endpoints within the same request lifecycle.
+- A **deferred replay** mode MAY be enabled for backfill operations. Code enabling this path MUST gate the feature behind an explicit configuration flag and document the associated runbook.
+- All modes MUST preserve deterministic ordering of fills and must log each dispatched order with a monotonic sequence identifier.
+
+## Communication Headers
+- Every inbound request MUST include `X-TradeAgent-Account` to scope the tenant and authorization context.
+- Propagate `X-TradeAgent-Request-ID` to downstream services to preserve distributed tracing continuity.
+- Include optional `X-TradeAgent-Sandbox` header to mark paper-trading flows. Do not attempt live execution when the header is present and true.
+- Reject requests missing mandatory headers with HTTP 400 and a machine-readable error payload.
+
+## Endpoints
+- `POST /trade-agent/v1/signals` ingests trade intents originating from master accounts. Validate payload schema, confirm authorization, and enqueue replication tasks.
+- `POST /trade-agent/v1/executions` records broker execution callbacks. Ensure idempotency by hashing provider identifiers and broker ticket numbers.
+- `GET /trade-agent/v1/health` returns readiness and liveness information with dependency probes for broker APIs, message queues, and data stores.
+- `GET /trade-agent/v1/runs/{run_id}` surfaces execution audit trails, including timestamps, fill states, and risk guard outcomes.
+
+## Idempotency Rules
+- All mutating endpoints MUST accept an `Idempotency-Key` header. Persist the key alongside a digest of the normalized request body for 24 hours.
+- If a duplicate request is detected, return the original response payload and status code without re-invoking side effects.
+- Broker callbacks SHOULD be replay-safe. When reconciling executions, guard against double-counted fills by checking both broker ticket and TradeAgentEA sequence IDs.
+- Background workers reprocessing messages MUST record completion checkpoints before acknowledging queue events to avoid replays without persisted state.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # kopitra
-A copy trading system infrastructure
+
+A copy trading system infrastructure.
+
+## Project Guideposts
+- [TODO](TODO.md) – Roadmap milestones, reliability work, and documentation backlog.
+- [TradeAgentEA Operating Guide](AGENTS.md) – Agent mode, communication headers, endpoints, and idempotency expectations.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,33 @@
+# Project Planning TODO
+
+## Phased Milestones
+1. **Phase 1 – Core Copy Trading Pipeline**
+   - Stabilize ingestion of master account trade signals with latency budgets under 150 ms.
+   - Implement secure credential vaulting and role-based access for broker connections.
+   - Deliver a minimal monitoring dashboard covering trade replication health.
+2. **Phase 2 – Portfolio Intelligence**
+   - Introduce allocation strategies (mirrored lots, proportional risk, and fixed fractional).
+   - Layer in configurable risk guards for drawdown, exposure, and trade frequency.
+   - Expose performance analytics APIs for downstream reporting tools.
+3. **Phase 3 – Ecosystem Integrations**
+   - Add broker-specific adapters for priority partners and sandbox providers.
+   - Offer webhook and message bus connectors for external automation workflows.
+   - Launch developer SDKs and documentation for third-party strategy authors.
+
+## Reliability Tasks
+- Instrument trade replication pipeline with distributed tracing and SLO dashboards.
+- Build automated failover for strategy hosts with warm standby replicas.
+- Implement circuit breakers and dead-letter queues around broker RPC failures.
+- Schedule regular disaster-recovery game days to validate runbooks.
+
+## Technical Debt
+- Refactor execution engine to isolate broker adapters behind a unified interface.
+- Replace ad hoc polling loops with event-driven workers backed by message queues.
+- Upgrade configuration management to support per-tenant overrides and secrets.
+- Consolidate duplicated trade model validations across services.
+
+## Documentation Backlog
+- Author a "Getting Started" guide for copy-trading operators and tenant admins.
+- Document broker onboarding procedures, including compliance prerequisites.
+- Create reference diagrams for signal flow, scaling topology, and observability stack.
+- Maintain an API changelog covering release notes and migration guidance.


### PR DESCRIPTION
## Summary
- add a project TODO roadmap covering milestones, reliability, technical debt, and documentation
- capture TradeAgentEA operating expectations in AGENTS.md
- link the planning and agent guides from the README for quick discovery

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68c954e80d188320a115833fdcc18d18