### PR TITLE
Fix Bicep deployment errors and clean up warnings

### DIFF
--- a/infra/bicep/containerapps.bicep
+++ b/infra/bicep/containerapps.bicep
@@ -10,9 +10,6 @@ param tags object
 @description('Short workload identifier used for naming child resources and diagnostics.')
 param workloadName string
 
-@description('Target environment suffix.')
-param environment string
-
 @description('Name assigned to the Log Analytics workspace that backs the Container Apps environment.')
 param logAnalyticsName string
 
@@ -34,8 +31,8 @@ param registryServer string
 @description('Target ingress port exposed by the application.')
 param targetPort int = 8080
 
-@description('CPU cores allocated to the container.')
-param cpu double = 0.25
+@description('CPU cores allocated to the container. Provide the value as a string that can be parsed as JSON (e.g. "0.25").')
+param cpu string = '0.25'
 
 @description('Memory allocated to the container.')
 param memory string = '0.5Gi'
@@ -69,6 +66,8 @@ resource managedEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
   }
 }
 
+var cpuValue = json(cpu)
+
 resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
   name: containerAppName
   location: location
@@ -97,7 +96,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
           image: containerImage
           env: containerEnvVars
           resources: {
-            cpu: cpu
+            cpu: cpuValue
             memory: memory
           }
         }

--- a/infra/bicep/cosmosdb.bicep
+++ b/infra/bicep/cosmosdb.bicep
@@ -10,12 +10,6 @@ param accountName string
 @description('Tag dictionary applied to all Cosmos resources.')
 param tags object
 
-@description('Short workload identifier used for default resource names.')
-param workloadName string
-
-@description('Environment suffix appended to child resources.')
-param environment string
-
 @description('SQL API database name.')
 param databaseName string
 
@@ -56,7 +50,8 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
 }
 
 resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-04-15' = {
-  name: '${cosmosAccount.name}/${databaseName}'
+  name: databaseName
+  parent: cosmosAccount
   tags: tags
   properties: {
     resource: {
@@ -67,7 +62,8 @@ resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-04
 }
 
 resource sqlContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-04-15' = {
-  name: '${cosmosAccount.name}/${databaseName}/${containerName}'
+  name: containerName
+  parent: sqlDatabase
   tags: tags
   properties: {
     resource: {

--- a/infra/bicep/servicebus.bicep
+++ b/infra/bicep/servicebus.bicep
@@ -10,9 +10,6 @@ param namespaceName string
 @description('Tag dictionary applied to all resources created by this module.')
 param tags object
 
-@description('Target environment suffix used for child resource names.')
-param environment string
-
 @description('Operations queue name. Must be unique within the namespace.')
 param operationsQueueName string
 
@@ -33,7 +30,8 @@ resource namespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
 }
 
 resource operationsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
-  name: '${namespace.name}/${operationsQueueName}'
+  name: operationsQueueName
+  parent: namespace
   properties: {
     lockDuration: 'PT30S'
     maxDeliveryCount: 5
@@ -43,7 +41,8 @@ resource operationsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-prev
 }
 
 resource commandsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
-  name: '${namespace.name}/${commandsQueueName}'
+  name: commandsQueueName
+  parent: namespace
   properties: {
     lockDuration: 'PT30S'
     maxDeliveryCount: 5

--- a/infra/bicep/sql.bicep
+++ b/infra/bicep/sql.bicep
@@ -34,7 +34,8 @@ resource sqlServer 'Microsoft.Sql/servers@2022-02-01-preview' = {
 }
 
 resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-02-01-preview' = {
-  name: '${sqlServer.name}/${databaseName}'
+  name: databaseName
+  parent: sqlServer
   location: location
   tags: tags
   sku: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -76,7 +76,6 @@ resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-pr
   location: location
   sku: {
     name: 'Basic'
-    tier: 'Basic'
   }
   tags: tags
   properties: {
@@ -91,7 +90,6 @@ module containerAppModule 'bicep/containerapps.bicep' = {
     location: location
     tags: tags
     workloadName: workloadName
-    environment: environment
     logAnalyticsName: logAnalyticsName
     managedEnvironmentName: managedEnvironmentName
     containerAppName: gatewayAppName
@@ -111,7 +109,7 @@ module containerAppModule 'bicep/containerapps.bicep' = {
       }
       {
         name: 'SQL_SERVER_FQDN'
-        value: '${sqlServerName}.database.windows.net'
+        value: '${sqlServerName}.${az.environment().suffixes.sqlServerHostname}'
       }
       {
         name: 'SQL_DATABASE_NAME'
@@ -119,7 +117,7 @@ module containerAppModule 'bicep/containerapps.bicep' = {
       }
       {
         name: 'KEY_VAULT_URI'
-        value: 'https://${keyVaultName}.vault.azure.net/'
+        value: 'https://${keyVaultName}.${az.environment().suffixes.keyVaultDns}/'
       }
     ]
     registryServer: containerRegistry.properties.loginServer
@@ -132,7 +130,6 @@ module serviceBusModule 'bicep/servicebus.bicep' = {
     namespaceName: serviceBusNamespaceName
     location: location
     tags: tags
-    environment: environment
     operationsQueueName: operationsQueueName
     commandsQueueName: commandsQueueName
   }
@@ -160,14 +157,20 @@ module keyVaultModule 'bicep/keyvault.bicep' = {
   }
 }
 
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' existing = {
+  name: serviceBusNamespaceName
+}
+
+resource keyVaultResource 'Microsoft.KeyVault/vaults@2023-02-01' existing = {
+  name: keyVaultName
+}
+
 module cosmosModule 'bicep/cosmosdb.bicep' = if (deployCosmos) {
   name: 'cosmosDb'
   params: {
     accountName: cosmosAccountName
     location: location
     tags: tags
-    workloadName: workloadName
-    environment: environment
     databaseName: cosmosDatabaseName
     containerName: cosmosContainerName
   }
@@ -210,9 +213,12 @@ resource functionPlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   tags: tags
 }
 
-var storageAccountKeys = listKeys(storageAccount.id, '2022-09-01')
+var storageAccountKeys = storageAccount.listKeys()
 var storageAccountKey = storageAccountKeys.keys[0].value
-var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccountKey};EndpointSuffix=${environment().suffixes.storage}'
+var storageConnectionString = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};AccountKey=${storageAccountKey};EndpointSuffix=${az.environment().suffixes.storage}'
+var sqlServerHostSuffix = az.environment().suffixes.sqlServerHostname
+var keyVaultDnsSuffix = az.environment().suffixes.keyVaultDns
+var keyVaultUri = 'https://${keyVaultName}.${keyVaultDnsSuffix}/'
 
 resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
   name: functionAppName
@@ -267,7 +273,7 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
         }
         {
           name: 'SQL_SERVER_FQDN'
-          value: '${sqlServerName}.database.windows.net'
+          value: '${sqlServerName}.${sqlServerHostSuffix}'
         }
         {
           name: 'SQL_DATABASE_NAME'
@@ -275,7 +281,7 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
         }
         {
           name: 'KEY_VAULT_URI'
-          value: 'https://${keyVaultName}.vault.azure.net/'
+          value: keyVaultUri
         }
       ]
     }
@@ -317,8 +323,8 @@ resource acrPullAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' 
 }
 
 resource serviceBusSenderAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(serviceBusModule.outputs.namespaceId, containerAppModule.outputs.containerAppPrincipalId, 'sb-sender')
-  scope: resourceId('Microsoft.ServiceBus/namespaces', serviceBusNamespaceName)
+  name: guid(subscription().id, serviceBusNamespaceName, gatewayAppName, 'sb-sender')
+  scope: serviceBusNamespace
   properties: {
     principalId: containerAppModule.outputs.containerAppPrincipalId
     principalType: 'ServicePrincipal'
@@ -327,8 +333,8 @@ resource serviceBusSenderAssignment 'Microsoft.Authorization/roleAssignments@202
 }
 
 resource serviceBusReceiverAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(serviceBusModule.outputs.namespaceId, functionApp.identity.principalId, 'sb-receiver')
-  scope: resourceId('Microsoft.ServiceBus/namespaces', serviceBusNamespaceName)
+  name: guid(subscription().id, serviceBusNamespaceName, functionAppName, 'sb-receiver')
+  scope: serviceBusNamespace
   properties: {
     principalId: functionApp.identity.principalId
     principalType: 'ServicePrincipal'
@@ -337,8 +343,8 @@ resource serviceBusReceiverAssignment 'Microsoft.Authorization/roleAssignments@2
 }
 
 resource serviceBusSenderAssignmentFunctions 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(serviceBusModule.outputs.namespaceId, functionApp.identity.principalId, 'sb-sender-func')
-  scope: resourceId('Microsoft.ServiceBus/namespaces', serviceBusNamespaceName)
+  name: guid(subscription().id, serviceBusNamespaceName, functionAppName, 'sb-sender-func')
+  scope: serviceBusNamespace
   properties: {
     principalId: functionApp.identity.principalId
     principalType: 'ServicePrincipal'
@@ -347,8 +353,8 @@ resource serviceBusSenderAssignmentFunctions 'Microsoft.Authorization/roleAssign
 }
 
 resource keyVaultContainerAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(keyVaultModule.outputs.vaultId, containerAppModule.outputs.containerAppPrincipalId, 'kv-reader')
-  scope: resourceId('Microsoft.KeyVault/vaults', keyVaultName)
+  name: guid(subscription().id, keyVaultName, gatewayAppName, 'kv-reader')
+  scope: keyVaultResource
   properties: {
     principalId: containerAppModule.outputs.containerAppPrincipalId
     principalType: 'ServicePrincipal'
@@ -357,8 +363,8 @@ resource keyVaultContainerAssignment 'Microsoft.Authorization/roleAssignments@20
 }
 
 resource keyVaultFunctionAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(keyVaultModule.outputs.vaultId, functionApp.identity.principalId, 'kv-reader-func')
-  scope: resourceId('Microsoft.KeyVault/vaults', keyVaultName)
+  name: guid(subscription().id, keyVaultName, functionAppName, 'kv-reader-func')
+  scope: keyVaultResource
   properties: {
     principalId: functionApp.identity.principalId
     principalType: 'ServicePrincipal'
@@ -373,9 +379,9 @@ output containerRegistryLoginServer string = '${containerRegistry.name}.azurecr.
 output serviceBusNamespace string = '${serviceBusNamespaceName}.servicebus.windows.net'
 output operationsQueue string = operationsQueueName
 output commandsQueue string = commandsQueueName
-output sqlServerFqdn string = '${sqlServerName}.database.windows.net'
+output sqlServerFqdn string = '${sqlServerName}.${sqlServerHostSuffix}'
 output sqlDatabaseName string = sqlDatabaseName
 output functionAppName string = functionAppName
 output staticWebAppName string = staticWebAppName
-output keyVaultUri string = 'https://${keyVaultName}.vault.azure.net/'
+output keyVaultUri string = keyVaultUri
 output cosmosAccountName string = deployCosmos ? cosmosAccountName : ''


### PR DESCRIPTION
## Summary
- remove unused parameters and adopt parent resource syntax across Cosmos DB, Service Bus, and SQL modules
- update the main deployment to rely on Azure environment suffixes, resource function helpers, and deterministic role assignment names
- allow the container app CPU input to be parsed from a JSON-compatible string to satisfy the Bicep type system

## Testing
- n/a (Bicep CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e06ea911b083209825909a5a1d4ee0