### PR TITLE
Fix Bicep deployment errors and clean up warnings

### DIFF
--- a/infra/bicep/containerapps.bicep
+++ b/infra/bicep/containerapps.bicep
@@ -10,9 +10,6 @@ param tags object
 @description('Short workload identifier used for naming child resources and diagnostics.')
 param workloadName string
 
-@description('Target environment suffix.')
-param environment string
-
 @description('Name assigned to the Log Analytics workspace that backs the Container Apps environment.')
 param logAnalyticsName string
 
@@ -34,8 +31,8 @@ param registryServer string
 @description('Target ingress port exposed by the application.')
 param targetPort int = 8080
 
-@description('CPU cores allocated to the container.')
-param cpu double = 0.25
+@description('CPU cores allocated to the container. Provide the value as a string that can be parsed as JSON (e.g. "0.25").')
+param cpu string = '0.25'
 
 @description('Memory allocated to the container.')
 param memory string = '0.5Gi'
@@ -69,6 +66,8 @@ resource managedEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' = {
   }
 }
 
+var cpuValue = json(cpu)
+
 resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
   name: containerAppName
   location: location
@@ -97,7 +96,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
           image: containerImage
           env: containerEnvVars
           resources: {
-            cpu: cpu
+            cpu: cpuValue
             memory: memory
           }
         }

--- a/infra/bicep/cosmosdb.bicep
+++ b/infra/bicep/cosmosdb.bicep
@@ -10,12 +10,6 @@ param accountName string
 @description('Tag dictionary applied to all Cosmos resources.')
 param tags object
 
-@description('Short workload identifier used for default resource names.')
-param workloadName string
-
-@description('Environment suffix appended to child resources.')
-param environment string
-
 @description('SQL API database name.')
 param databaseName string
 
@@ -56,7 +50,8 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2023-04-15' = {
 }
 
 resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-04-15' = {
-  name: '${cosmosAccount.name}/${databaseName}'
+  name: databaseName
+  parent: cosmosAccount
   tags: tags
   properties: {
     resource: {
@@ -67,7 +62,8 @@ resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2023-04
 }
 
 resource sqlContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2023-04-15' = {
-  name: '${cosmosAccount.name}/${databaseName}/${containerName}'
+  name: containerName
+  parent: sqlDatabase
   tags: tags
   properties: {
     resource: {

--- a/infra/bicep/servicebus.bicep
+++ b/infra/bicep/servicebus.bicep
@@ -10,9 +10,6 @@ param namespaceName string
 @description('Tag dictionary applied to all resources created by this module.')
 param tags object
 
-@description('Target environment suffix used for child resource names.')
-param environment string
-
 @description('Operations queue name. Must be unique within the namespace.')
 param operationsQueueName string
 
@@ -33,7 +30,8 @@ resource namespace 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
 }
 
 resource operationsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
-  name: '${namespace.name}/${operationsQueueName}'
+  name: operationsQueueName
+  parent: namespace
   properties: {
     lockDuration: 'PT30S'
     maxDeliveryCount: 5
@@ -43,7 +41,8 @@ resource operationsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-prev
 }
 
 resource commandsQueue 'Microsoft.ServiceBus/namespaces/queues@2022-10-01-preview' = {
-  name: '${namespace.name}/${commandsQueueName}'
+  name: commandsQueueName
+  parent: namespace
   properties: {
     lockDuration: 'PT30S'
     maxDeliveryCount: 5

--- a/infra/bicep/sql.bicep
+++ b/infra/bicep/sql.bicep
@@ -34,7 +34,8 @@ resource sqlServer 'Microsoft.Sql/servers@2022-02-01-preview' = {
 }
 
 resource sqlDatabase 'Microsoft.Sql/servers/databases@2022-02-01-preview' = {
-  name: '${sqlServer.name}/${databaseName}'
+  name: databaseName
+  parent: sqlServer
   location: location
   tags: tags
   sku: {


### PR DESCRIPTION
## Summary
- remove unused parameters and adopt parent resource syntax across Cosmos DB, Service Bus, and SQL modules
- update the main deployment to rely on Azure environment suffixes, resource function helpers, and deterministic role assignment names, including corrected key vault suffix usage
- allow the container app CPU input to be parsed from a JSON-compatible string to satisfy the Bicep type system

## Testing
- n/a (Bicep CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e06ea911b083209825909a5a1d4ee0