### PR TITLE
Add go-task orchestration for local services

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,22 @@ SignalR bindings on Azure Functions supplement the HTTP API for live dashboard u
 
    # Launch the EA within its trading terminal and point it to http://localhost:8080 (or tunnel to Functions/App Service endpoints)
    ```
+
+### Local orchestration with go-task
+
+For environments where Docker is unavailable, the repository now includes a `Taskfile.yml` that orchestrates the Service Bus emulator, Rust gateway, Azure Functions app, and Ops Console frontend in parallel using [go-task](https://taskfile.dev).
+
+1. Install go-task following the [official instructions](https://taskfile.dev/installation/).
+2. From the repository root, start the entire local stack:
+   ```bash
+   task dev
+   ```
+   The task starts all services concurrently and streams their logs. Press `Ctrl+C` to stop every process together.
+3. Run every module's test suite in parallel:
+   ```bash
+   task verify
+   ```
+   Individual tasks (for example `task gateway:test` or `task opsconsole:dev`) remain available when you need to work on a single component.
 5. **Execute Tests & Linters**
    - Rust gateway:
      ```bash

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,118 @@
+version: '3'
+
+description: >
+  Developer task runners for running Kopitra services and tests without Docker.
+
+vars:
+  CARGO: '{{.CARGO | default "cargo"}}'
+  DOTNET: '{{.DOTNET | default "dotnet"}}'
+  NPM: '{{.NPM | default "npm"}}'
+  RUST_LOG: '{{.RUST_LOG | default "info"}}'
+
+tasks:
+  default:
+    desc: Alias for `task dev`.
+    cmds:
+      - task: dev
+
+  dev:
+    desc: Start the local stack for integration testing without Docker.
+    deps:
+      - servicebus:run
+      - gateway:run
+      - functions:start
+      - opsconsole:dev
+
+  verify:
+    desc: Run all module test suites in parallel.
+    deps:
+      - servicebus:test
+      - gateway:test
+      - functions:test
+      - opsconsole:test
+
+  servicebus:run:
+    dir: servicebus-emulator
+    desc: Run the Service Bus emulator locally.
+    env:
+      RUST_LOG: '{{.RUST_LOG}}'
+    cmds:
+      - '{{.CARGO}} run'
+
+  servicebus:test:
+    dir: servicebus-emulator
+    desc: Run the Service Bus emulator unit tests.
+    env:
+      RUST_LOG: '{{.RUST_LOG}}'
+    cmds:
+      - '{{.CARGO}} test'
+
+  gateway:run:
+    dir: gateway
+    desc: Run the Trade Agent gateway locally.
+    env:
+      RUST_LOG: '{{.RUST_LOG}}'
+      EA_SERVICE_BUS_EMULATOR_BASE_URL: '{{.EA_SERVICE_BUS_EMULATOR_BASE_URL | default "http://localhost:7075/"}}'
+      EA_SERVICE_BUS_QUEUE: '{{.EA_SERVICE_BUS_QUEUE | default "ea-admin"}}'
+      EA_SERVICE_BUS_NAMESPACE: '{{.EA_SERVICE_BUS_NAMESPACE | default "emulator"}}'
+      EA_SERVICE_BUS_POLICY: '{{.EA_SERVICE_BUS_POLICY | default "emulator"}}'
+      EA_SERVICE_BUS_KEY: '{{.EA_SERVICE_BUS_KEY | default "emulator"}}'
+    cmds:
+      - '{{.CARGO}} run'
+
+  gateway:test:
+    dir: gateway
+    desc: Run the Rust gateway test suite.
+    env:
+      RUST_LOG: '{{.RUST_LOG}}'
+    cmds:
+      - '{{.CARGO}} fmt --check'
+      - '{{.CARGO}} test'
+
+  functions:start:
+    dir: functions
+    desc: Start the Azure Functions management API locally.
+    cmds:
+      - '{{.DOTNET}} build Functions.sln'
+      - '{{.DOTNET}} run --project src/Kopitra.ManagementApi/Kopitra.ManagementApi.csproj'
+
+  functions:test:
+    dir: functions
+    desc: Run the management API unit tests.
+    cmds:
+      - '{{.DOTNET}} test Functions.sln'
+
+  opsconsole:install:
+    dir: opsconsole
+    internal: true
+    status:
+      - test -f node_modules/.task-install.stamp
+      - test node_modules/.task-install.stamp -nt package.json
+      - test node_modules/.task-install.stamp -nt package-lock.json
+    cmds:
+      - '{{.NPM}} install'
+      - touch node_modules/.task-install.stamp
+
+  opsconsole:dev:
+    dir: opsconsole
+    desc: Start the Ops Console frontend in development mode.
+    deps:
+      - opsconsole:install
+    cmds:
+      - '{{.NPM}} run dev -- --host 0.0.0.0'
+
+  opsconsole:test:
+    dir: opsconsole
+    desc: Run the Ops Console Vitest suite.
+    deps:
+      - opsconsole:install
+    cmds:
+      - '{{.NPM}} test'
+
+  opsconsole:lint:
+    dir: opsconsole
+    desc: Run the Ops Console ESLint checks.
+    deps:
+      - opsconsole:install
+    cmds:
+      - '{{.NPM}} run lint'


### PR DESCRIPTION
## Summary
- add a Taskfile that can start the service bus emulator, Rust gateway, Azure Functions app, and Ops Console without Docker
- provide go-task targets for running each module's test suite and linting helpers
- document the new go-task workflow in the README for developers who cannot use Docker

## Testing
- not run (go-task is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e121cfa5e083209494ecd232b1e3b3