### PR TITLE
Add debug flag to Azure deployment workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,7 +88,8 @@ jobs:
             --resource-group "$RESOURCE_GROUP" \
             --template-file infra/main.bicep \
             --parameters @${PARAMETERS_FILE} \
-            --parameters sqlAdministratorPassword="$SQL_ADMIN_PASSWORD"
+            --parameters sqlAdministratorPassword="$SQL_ADMIN_PASSWORD" \
+            --debug
 
   gateway:
     name: Gateway pipeline


### PR DESCRIPTION
## Summary
- add the --debug flag to the az deployment group create command in the CI/CD workflow to increase logging detail

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e1357d26e08320b7e12de65dc62ac2