### PR TITLE
Fix static web app deployment location handling

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -12,6 +12,16 @@ param environment string
 @description('Azure region for the deployment. Defaults to the resource group location.')
 param location string = resourceGroup().location
 
+@description('Azure region for the Static Web App. Must be one of the platform-supported regions.')
+@allowed([
+  'westus2'
+  'centralus'
+  'eastus2'
+  'westeurope'
+  'eastasia'
+])
+param staticWebAppLocation string = 'eastasia'
+
 @description('Short workload identifier used for naming and tagging.')
 param workloadName string = 'kopitra'
 
@@ -286,7 +296,7 @@ resource functionApp 'Microsoft.Web/sites@2022-09-01' = {
 
 resource staticWebApp 'Microsoft.Web/staticSites@2022-03-01' = {
   name: staticWebAppName
-  location: location
+  location: staticWebAppLocation
   sku: {
     name: 'Free'
     tier: 'Free'

--- a/infra/parameters/dev.json
+++ b/infra/parameters/dev.json
@@ -8,6 +8,9 @@
     "location": {
       "value": "japaneast"
     },
+    "staticWebAppLocation": {
+      "value": "eastasia"
+    },
     "workloadName": {
       "value": "kopitra"
     },


### PR DESCRIPTION
## Summary
- add a dedicated parameter for choosing a supported Azure Static Web App region
- default the static site deployment to eastasia so environments in unsupported regions can still deploy
- document the default region in the dev parameter file for clarity

## Testing
- `az bicep build --file infra/main.bicep --stdout` *(fails: HTTPSConnectionPool(host='aka.ms', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68e13e6e399083209fad01c31383f0c6