### PR TITLE
Document container app troubleshooting and harden deployment pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -164,6 +164,36 @@ jobs:
           docker tag gateway "$ACR_LOGIN_SERVER/${WORKLOAD_NAME}-gateway:${GITHUB_SHA}"
           docker push "$ACR_LOGIN_SERVER/${WORKLOAD_NAME}-gateway:${GITHUB_SHA}"
 
+      - name: Verify image availability
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          az acr repository show-tags \
+            --name "$ACR_NAME" \
+            --repository "${WORKLOAD_NAME}-gateway" \
+            --orderby time_desc \
+            --top 5
+          if ! az acr repository show-manifests \
+            --name "$ACR_NAME" \
+            --repository "${WORKLOAD_NAME}-gateway" \
+            --query "[?tags[?@=='${GITHUB_SHA}']]" -o tsv | grep -q .; then
+            echo "Container image tag ${GITHUB_SHA} was not found in ${WORKLOAD_NAME}-gateway" >&2
+            echo "Confirm that the push step completed successfully." >&2
+            exit 1
+          fi
+
+      - name: Confirm Container App exists
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          if ! az containerapp show \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" >/dev/null 2>&1; then
+            echo "Container App $CONTAINER_APP_NAME not found in $RESOURCE_GROUP" >&2
+            echo "Ensure the infra job completed successfully before redeploying." >&2
+            exit 1
+          fi
+
       - name: Update Container App revision
         if: github.event_name != 'pull_request'
         run: |
@@ -171,6 +201,31 @@ jobs:
             --name "$CONTAINER_APP_NAME" \
             --resource-group "$RESOURCE_GROUP" \
             --image "$ACR_LOGIN_SERVER/${WORKLOAD_NAME}-gateway:${GITHUB_SHA}"
+
+      - name: Capture Container App diagnostics
+        if: failure() && github.event_name != 'pull_request'
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          echo "Collecting Container App diagnostics for $CONTAINER_APP_NAME" >&2
+          az containerapp show \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP"
+          az containerapp revision list \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --output table
+          LATEST_REVISION=$(az containerapp revision list \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --query "[0].name" -o tsv || true)
+          if [ -n "$LATEST_REVISION" ]; then
+            az containerapp logs show \
+              --name "$CONTAINER_APP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --revision "$LATEST_REVISION" \
+              --tail 50 || true
+          fi
 
   functions:
     name: Functions pipeline

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The pipeline performs these deploy steps on mainline pushes:
 
 Pull requests continue to run format, lint, build, and test jobs without touching Azure resources.
 
+Refer to [`docs/deployment/container-app-troubleshooting.md`](docs/deployment/container-app-troubleshooting.md) for a step-by-step checklist to investigate Container App deployment failures and validate that the latest image tag reached the registry.
+
 ## Cross-System API Specifications
 This section reflects the current message flows between the four core systems. Payloads are expressed as JSON; all timestamps are ISO-8601 with millisecond precision and UTC offset (`2024-03-27T02:09:11.124Z`).
 

--- a/docs/deployment/container-app-troubleshooting.md
+++ b/docs/deployment/container-app-troubleshooting.md
@@ -1,0 +1,100 @@
+# Container App Deployment Troubleshooting Guide
+
+This guide explains how to diagnose Azure Container App deployment failures that originate from the CI/CD workflow.
+
+## 1. Understand the workflow stages
+
+The `CI/CD` workflow defines three relevant jobs:
+
+1. **`infra`** provisions or updates the resource group, Azure Container Registry (ACR), Container Apps environment, and supporting services through Bicep templates.
+2. **`gateway`** builds the container image, publishes it to ACR, and updates the Container App revision.
+3. **`opsconsole`** deploys the Static Web App assets (not directly related to the gateway runtime).
+
+A failure in the `gateway` job usually means the container image was not published or the Container App could not pull it.
+
+## 2. Inspect workflow logs in GitHub Actions
+
+1. Open the failed run in **Actions** and expand the `gateway` job.
+2. Review the "Push image to ACR" and "Update Container App revision" steps for Azure CLI errors.
+3. Re-run the workflow with step-debug logging if the failure is unclear:
+   - Add the repository secret `ACTIONS_STEP_DEBUG=true`.
+   - Re-run the job; GitHub Actions will emit verbose CLI output.
+
+## 3. Validate the container image in Azure Container Registry
+
+Run the following commands from a local terminal (or Cloud Shell) after authenticating with `az login`:
+
+```bash
+RESOURCE_GROUP=<your resource group>
+ACR_NAME=<workload><environment>acr
+IMAGE_REPOSITORY=<workload>-gateway
+IMAGE_TAG=<commit SHA or tag>
+
+# Confirm the registry exists
+az acr show --name "$ACR_NAME"
+
+# List recent image tags
+az acr repository show-tags \
+  --name "$ACR_NAME" \
+  --repository "$IMAGE_REPOSITORY" \
+  --orderby time_desc \
+  --top 5
+
+# Confirm the target tag exists
+az acr repository show-manifests \
+  --name "$ACR_NAME" \
+  --repository "$IMAGE_REPOSITORY" \
+  --query "[?tags[?@=='$IMAGE_TAG']]" \
+  --output table
+```
+
+If the expected tag is missing, the GitHub Actions job likely failed before pushing or lacked permission to authenticate against ACR.
+
+## 4. Check Container App state and revisions
+
+Confirm that the Container App exists and inspect recent revisions:
+
+```bash
+CONTAINER_APP_NAME=<workload>-gateway-aca-<environment>
+
+# Display the Container App definition
+az containerapp show \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP"
+
+# Review the latest revisions and their status
+az containerapp revision list \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --output table
+```
+
+Look for revisions stuck in `Failed` or `CrashLoopBackOff`. The `image` column confirms which container tag each revision attempted to start.
+
+## 5. Tail runtime logs for deployment errors
+
+Fetch application logs from the most recent revision to surface startup failures:
+
+```bash
+LATEST_REVISION=$(az containerapp revision list \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "[0].name" -o tsv)
+
+az containerapp logs show \
+  --name "$CONTAINER_APP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --revision "$LATEST_REVISION" \
+  --follow
+```
+
+Authentication or pull errors typically appear here when the Container App cannot reach ACR.
+
+## 6. Common remediation steps
+
+- **Missing image**: Re-run the workflow after confirming `Push image to ACR` succeeded, or trigger a manual rebuild with `az acr build`.
+- **Unauthorized to pull**: Verify the Container App's managed identity has the `AcrPull` role on the registry (`az role assignment list --assignee <principalId> --scope <ACR resource ID>`).
+- **Stale registry binding**: Run `az containerapp registry set --server <loginServer> --identity system` to reapply the managed identity binding.
+- **Configuration drift**: Re-run the `infra` job to apply the latest Bicep templates, then redeploy the container.
+
+Following this sequence isolates whether the issue stems from the build, publish, or deployment stage and provides actionable diagnostics for each case.


### PR DESCRIPTION
## Summary
- add a deployment troubleshooting guide that walks through validating images, container apps, and logs
- surface the new diagnostics guide from the README so contributors can find it alongside the CI/CD overview
- enhance the gateway GitHub Actions job to verify image pushes, ensure the Container App exists, and emit diagnostics on failure

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e14df0c2d0832092609c076c2caeca